### PR TITLE
Changed field returns the original value

### DIFF
--- a/src/JsonDiffer/JsonDifferentiator.cs
+++ b/src/JsonDiffer/JsonDifferentiator.cs
@@ -85,7 +85,7 @@ namespace JsonDiffer
                 {
                     if (!JToken.DeepEquals(first?[property], second?[property]))
                     {
-                        difference[$"*{property}"] = value;
+                        difference[$"*{property}"] = second?[property];
                     }
 
                     continue;


### PR DESCRIPTION
A changed field returns the original value and not the new value. 
I would assume the "To" value is what is of interest? 
It is at least in my project. If that is not always the case, an option to this suggested change would be a flag..
Test:
            var testOriginal = "{\"O\":{\"Testvalue\":1632}}";
            var testChanged = "{\"O\":{\"Testvalue\":1635}}";
            var differences = JsonDiffer.JsonDifferentiator.Differentiate(JToken.Parse(testOriginal), JToken.Parse(testChanged));

differences = {{
  "*O": {
    "*Testvalue": 1632
  }
}}

Where 1635 is the value of interest.